### PR TITLE
chore(deps): trim Dependabot to monthly + grouped, drop pip no-op

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,38 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "melorga"
-    assignees:
-      - "melorga"
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "deps"
-      prefix-development: "deps-dev"
       include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
 
   - package-ecosystem: "terraform"
     directory: "/infrastructure/terraform"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "melorga"
-    assignees:
-      - "melorga"
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      terraform-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     commit-message:
       prefix: "deps"
       include: "scope"
+    labels:
+      - "dependencies"
+      - "terraform"
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "melorga"
-    assignees:
-      - "melorga"
-    commit-message:
-      prefix: "deps"
-      include: "scope"
+  # NOTE: dropped the root `pip` ecosystem. There is no requirements.txt /
+  # pyproject.toml / setup.py at the repo root, so Dependabot would never
+  # find anything to update -- the entry only generated scan notifications.
+  # Re-add scoped to a real Python source directory once one exists.


### PR DESCRIPTION
## Why

Was weekly with `open-pull-requests-limit: 10` across 3 ecosystems. The `pip` ecosystem scanned `/` which has no Python manifest — it produced zero useful PRs but generated scan notifications.

## What changes

- Drop the `pip` ecosystem at `/` (no `requirements.txt` / `pyproject.toml` / `setup.py` exists at the repo root). Re-add scoped to a real Python source directory once one exists.
- Remaining `github-actions` + `terraform /infrastructure/terraform`:
  - `interval: weekly` → `monthly`
  - `open-pull-requests-limit: 10` → `2`
  - Add `groups:` so minor/patch updates batch into one PR per ecosystem