### PR TITLE
fix(deps): point terraform Dependabot at directories that contain .tf files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,9 @@ updates:
       - "github-actions"
 
   - package-ecosystem: "terraform"
-    directory: "/infrastructure/terraform"
+    directories:
+      - "/infrastructure/terraform/environments/*"
+      - "/infrastructure/terraform/modules/*"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 2


### PR DESCRIPTION
## Summary

- Dependabot's `terraform` ecosystem entry pointed at `/infrastructure/terraform`, which contains no `.tf` files directly — they live in `environments/*/` and `modules/*/`.
- Dependabot does not recurse, so every run failed with `ERROR: No files found in /infrastructure/terraform` (see run [25616513127](https://github.com/melorga/infrastructure-scaffold/actions/runs/25616513127)).
- Switching to the plural `directories:` key (GA 2024) with globs fixes it and is forward-compatible with new envs/modules.

## Test plan

- [ ] Merge and wait for the next monthly Dependabot trigger (or trigger manually via repo Settings → Code security → Dependabot → "Check for updates").
- [ ] Confirm the run completes without `No files found` and that any PRs it opens are scoped to the right subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)